### PR TITLE
Rework state highlighting for the process instance #250

### DIFF
--- a/src/main/java/io/flowset/control/dto/ElementStatisticsData.java
+++ b/src/main/java/io/flowset/control/dto/ElementStatisticsData.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Haulmont 2026. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.flowset.control.dto;
+
+import io.flowset.uikit.component.bpmnviewer.model.ActivityInstanceStatisticsData;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Contains statistics for one process instance element.
+ */
+@Getter
+@Setter
+public class ElementStatisticsData implements ActivityInstanceStatisticsData {
+    protected String elementId;
+    protected Integer activeCount;
+    protected Integer completedCount;
+    protected Integer incidentCount;
+
+    public ElementStatisticsData(String elementId) {
+        this.elementId = elementId;
+    }
+
+    /**
+     * Increment the count of finished activity instances.
+     *
+     * @return current instance
+     */
+    public ElementStatisticsData incrementFinishedCount() {
+        if (this.completedCount == null) {
+            this.completedCount = 0;
+        }
+        this.completedCount++;
+        return this;
+    }
+
+    /**
+     * Increment the count of active activity instances.
+     *
+     * @return current instance
+     */
+    public ElementStatisticsData incrementActiveCount() {
+        if (this.activeCount == null) {
+            this.activeCount = 0;
+        }
+        this.activeCount++;
+        return this;
+    }
+}

--- a/src/main/java/io/flowset/control/service/activity/impl/ActivityServiceImpl.java
+++ b/src/main/java/io/flowset/control/service/activity/impl/ActivityServiceImpl.java
@@ -35,6 +35,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static io.flowset.control.util.EngineRestUtils.getCountResult;
@@ -108,6 +109,9 @@ public class ActivityServiceImpl implements ActivityService {
     public List<ActivityShortData> findFinishedActivities(String processInstanceId) {
         HistoricActivityInstanceQueryDto queryDto = createHistoricActivityInstanceQueryDto()
                 .processInstanceId(processInstanceId)
+                .sorting(Collections.singletonList(new HistoricActivityInstanceQueryDtoSortingInner()
+                        .sortBy(HistoricActivityInstanceQueryDtoSortingInner.SortByEnum.OCCURRENCE)
+                        .sortOrder(HistoricActivityInstanceQueryDtoSortingInner.SortOrderEnum.ASC)))
                 .finished(true);
 
         ResponseEntity<List<HistoricActivityInstanceDto>> response = historyApiClient.queryHistoricActivityInstances(null, null,

--- a/src/main/java/io/flowset/control/view/processdefinition/ProcessDefinitionDetailView.java
+++ b/src/main/java/io/flowset/control/view/processdefinition/ProcessDefinitionDetailView.java
@@ -175,7 +175,9 @@ public class ProcessDefinitionDetailView extends StandardDetailView<ProcessDefin
 
         updateAllRunningInstancesCount();
 
-        viewerFragment.showStatisticsButton(securitySupport.isEntityViewPermitted(ProcessActivityStatistics.class));
+        boolean statisticsEnabled = securitySupport.isEntityViewPermitted(ProcessActivityStatistics.class);
+        viewerFragment.showStatisticsButton(statisticsEnabled);
+        viewerFragment.setStatisticsVisible(statisticsEnabled);
     }
 
     @Subscribe

--- a/src/main/java/io/flowset/control/view/processdefinition/ProcessInstancesFragment.java
+++ b/src/main/java/io/flowset/control/view/processdefinition/ProcessInstancesFragment.java
@@ -143,7 +143,7 @@ public class ProcessInstancesFragment extends Fragment<VerticalLayout> {
         selectedActivityContainer.removeAll();
 
         Span activityBadge = new Span(messageBundle.formatMessage("selectedActivityBadge.text", elementId));
-        activityBadge.getElement().getThemeList().add("badge pill primary small");
+        activityBadge.getElement().getThemeList().add("badge pill primary warning small");
         activityBadge.setHeight("min-content");
 
         Tooltip tooltip = Tooltip.forComponent(activityBadge);
@@ -152,7 +152,7 @@ public class ProcessInstancesFragment extends Fragment<VerticalLayout> {
         JmixButton clearBtn = uiComponents.create(JmixButton.class);
         clearBtn.setIcon(VaadinIcon.CLOSE_SMALL.create());
         clearBtn.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
-        clearBtn.addClassNames(LumoUtility.TextColor.PRIMARY_CONTRAST);
+        clearBtn.addClassNames(LumoUtility.TextColor.WARNING_CONTRAST);
         clearBtn.addClickListener(clickEvent -> {
             clearActivity();
             uiEventPublisher.publishEventForCurrentUI(new ResetActivityEvent(this, elementId));

--- a/src/main/java/io/flowset/control/view/processinstance/ProcessInstanceDetailView.java
+++ b/src/main/java/io/flowset/control/view/processinstance/ProcessInstanceDetailView.java
@@ -32,6 +32,7 @@ import io.jmix.flowui.model.InstanceContainer;
 import io.jmix.flowui.model.InstanceLoader;
 import io.jmix.flowui.view.*;
 import io.flowset.control.dto.ActivityIncidentData;
+import io.flowset.control.dto.ElementStatisticsData;
 import io.flowset.control.entity.activity.ActivityInstanceTreeItem;
 import io.flowset.control.entity.activity.ActivityShortData;
 import io.flowset.control.entity.decisioninstance.HistoricDecisionInstanceShortData;
@@ -64,7 +65,6 @@ import org.springframework.context.event.EventListener;
 import org.jspecify.annotations.Nullable;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Route(value = "bpm/process-instances/:id", layout = DefaultMainViewParent.class)
 @ViewController("bpm_ProcessInstanceData.detail")
@@ -234,6 +234,8 @@ public class ProcessInstanceDetailView extends StandardDetailView<ProcessInstanc
         if (!Strings.isNullOrEmpty(processBpmnXml)) {
             emptyDiagramBox.setVisible(false);
             viewerFragment.initViewer(processBpmnXml);
+            viewerFragment.showBpmnModelColorsButton(true);
+            viewerFragment.showStatisticsButton(true);
             viewerFragment.addImportCompleteListener(event -> handleProcessXmlImportComplete());
             viewerFragment.addDecisionInstanceLinkOverlayClickListener(
                     event -> handleDecisionInstanceLinkOverlayClicked(event.getDecisionInstanceId()));
@@ -249,23 +251,46 @@ public class ProcessInstanceDetailView extends StandardDetailView<ProcessInstanc
         ProcessInstanceData processInstanceData = processInstanceDataDc.getItem();
         String processInstanceId = processInstanceData.getInstanceId();
 
-        showRunningActivities(processInstanceId);
-        showFinishedActivities(processInstanceId);
+        List<String> passedActivities = new ArrayList<>();
+        Map<String, ElementStatisticsData> passedActivityStats = new HashMap<>();
+        showRunningActivities(processInstanceId, passedActivityStats);
+        showFinishedActivities(processInstanceId, passedActivities, passedActivityStats);
+        showTokenPath(passedActivities);
 
         if (processInstanceData.getState() != ProcessInstanceState.COMPLETED) {
             List<ActivityIncidentData> incidents = incidentService.findRuntimeIncidents(processInstanceId);
-            viewerFragment.setIncidentCount(new SetIncidentCountCmd(incidents));
+            incidents.forEach(incident -> {
+                String elementId = incident.getElementId();
+                ElementStatisticsData elementStat = passedActivityStats.getOrDefault(elementId, new ElementStatisticsData(elementId));
+                elementStat.setIncidentCount(incident.getIncidentCount());
+            });
         }
+        viewerFragment.setActivityInstanceStatistics(new SetActivityInstanceStatisticsCmd(new ArrayList<>(
+                passedActivityStats.values())));
+        viewerFragment.setShowNotPassedAsDisabled(true);
     }
 
-    protected void showFinishedActivities(String processInstanceId) {
+    protected void showTokenPath(List<String> finishedActivities) {
+        List<String> runningActivityIds = runtimeActivityInstancesDc.getItems()
+                .stream().filter(treeItem -> treeItem.getParentActivityInstance() != null)
+                .map(ActivityInstanceTreeItem::getActivityId)
+                .toList();
+
+        viewerFragment.showPassedFlows(finishedActivities, runningActivityIds);
+    }
+
+    protected void showFinishedActivities(String processInstanceId, List<String> passedActivities, Map<String, ElementStatisticsData> activityStats) {
         List<ActivityShortData> finishedActivities = activityService.findFinishedActivities(processInstanceId);
 
         Map<String, List<String>> calledInstancesByActivityId = new HashMap<>();
         for (ActivityShortData activityData : finishedActivities) {
             String activityId = activityData.getActivityId();
             if (!Strings.isNullOrEmpty(activityId)) {
-                viewerFragment.setElementColor(new SetElementColorCmd(activityId, "#000000", "var(--bpmn-history-activity-color)"));
+                viewerFragment.addMarker(new AddMarkerCmd(activityId, ElementMarkerType.FINISHED_ACTIVITY));
+                passedActivities.add(activityId);
+                ElementStatisticsData elementStatisticsData = activityStats.getOrDefault(activityId, new ElementStatisticsData(activityId));
+                elementStatisticsData.incrementFinishedCount();
+                activityStats.put(activityId, elementStatisticsData);
             }
 
             showCalledDecisionOverlay(activityId);
@@ -275,17 +300,27 @@ public class ProcessInstanceDetailView extends StandardDetailView<ProcessInstanc
         showCalledInstanceOverlays(calledInstancesByActivityId);
     }
 
-    protected void showRunningActivities(String processInstanceId) {
-        Set<String> runtimeActivityIds = runtimeActivityInstancesDc.getItems()
-                .stream().filter(treeItem -> treeItem.getParentActivityInstance() != null)
-                .map(ActivityInstanceTreeItem::getActivityId)
-                .collect(Collectors.toSet());
+    protected void showRunningActivities(String processInstanceId, Map<String, ElementStatisticsData> activityStats) {
+        Set<String> runtimeActivityIds = new HashSet<>();
 
+        runtimeActivityInstancesDc.getItems().forEach(activityInstanceTreeItem -> {
+            if (activityInstanceTreeItem.getParentActivityInstance() != null) {
+                String activityId = activityInstanceTreeItem.getActivityId();
+                if (!Strings.isNullOrEmpty(activityId)) {
+                    ElementStatisticsData elementStatisticsData = activityStats.getOrDefault(activityId, new ElementStatisticsData(activityId));
+                    elementStatisticsData.incrementActiveCount();
+                    activityStats.put(activityId, elementStatisticsData);
+                    runtimeActivityIds.add(activityId);
+                }
+
+            }
+        });
         runtimeActivityIds.forEach(activityId -> {
             if (!Strings.isNullOrEmpty(activityId)) {
                 viewerFragment.addMarker(new AddMarkerCmd(activityId, ElementMarkerType.RUNNING_ACTIVITY));
             }
         });
+
 
         List<ActivityShortData> runningHistoricActivities = activityService.findRunningActivities(processInstanceId);
 

--- a/src/main/resources/META-INF/resources/styles/flowset-control.css
+++ b/src/main/resources/META-INF/resources/styles/flowset-control.css
@@ -8,7 +8,6 @@
 }
 
 html {
-    --bpmn-history-activity-color: rgba(162, 224, 172, 0.45);
     --dashboard-background-color: hsla(214, 61%, 25%, 0.02);
     --toggle-button-group-bg-color: var(--lumo-primary-color-10pct);
     --toggle-button-active-bg-color: var(--lumo-primary-color);

--- a/src/main/resources/META-INF/resources/styles/styles.css
+++ b/src/main/resources/META-INF/resources/styles/styles.css
@@ -4,6 +4,7 @@
  */
 
 @import './flowset-control.css';
+@import 'view/bpmn-viewer.css';
 @import 'view/about-product-view.css';
 @import 'view/main-view.css';
 @import 'view/main-view-top-menu.css';

--- a/src/main/resources/META-INF/resources/styles/view/bpmn-viewer.css
+++ b/src/main/resources/META-INF/resources/styles/view/bpmn-viewer.css
@@ -1,0 +1,6 @@
+.bpmn-viewer-left-side-actions {
+    background-color: var(--lumo-base-color);
+    border: 1px solid var(--lumo-contrast-20pct);
+    border-radius: var(--lumo-border-radius-m);
+    box-shadow: var(--lumo-box-shadow-xs);
+}


### PR DESCRIPTION
Update diagram visualization in ProcessInstanceDetailView

1. By default show not passed elements as disabled
2. Add option to show/hide colors from BPMN XML: by default, the custom colors are hidden on the diagram.
3. Add option to show/hide count of completed activity instances on activity
4. Rework showing statistics for running activity: show not only incident count, but also activity instance count.

Update diagram visualization in ProcessDefinitionDetailView: use orange color instead of primary for selecting an element with instances running on it